### PR TITLE
bug[create]: Use the correct template file name that use 'javat' as suffix

### DIFF
--- a/src/main/java/dev/webfx/cli/commands/Create.java
+++ b/src/main/java/dev/webfx/cli/commands/Create.java
@@ -174,7 +174,7 @@ public final class Create extends CommonSubcommand {
 
         private DevProjectModule createTagApplicationModule(TargetTag targetTag) throws IOException {
             if (targetTag == null)
-                return createSourceModule(prefix + "-application", helloWorld ? "JavaFxHelloWorldApplication.java" : "JavaFxApplication.java", javaFxApplication, false);
+                return createSourceModule(prefix + "-application", helloWorld ? "JavaFxHelloWorldApplication.javat" : "JavaFxApplication.javat", javaFxApplication, false);
             return createSourceModule(prefix + "-application-" + targetTag.name().toLowerCase(), null, null, true);
         }
     }


### PR DESCRIPTION
Use the correct template file name that use 'javat' as suffix.

To solve below exception when follow the tutorial of WebFX documentation, use command like:

`webfx create application --prefix webfx-example org.example.webfxexample.WebFxExampleApplication --helloWorld`

exception:
`java.lang.NullPointerException: Cannot invoke "String.replace(java.lang.CharSequence, java.lang.CharSequence)" because the return value of "dev.webfx.cli.util.textfile.ResourceTextFileReader.readTemplate(String)" is null
        at dev.webfx.cli.commands.Create$CreateSubCommand.createSourceModule(Create.java:70)
        at dev.webfx.cli.commands.Create$Application.createTagApplicationModule(Create.java:177)
        at dev.webfx.cli.commands.Create$Application.call(Create.java:166)
        at dev.webfx.cli.commands.Create$Application.call(Create.java:144)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2041)
        at picocli.CommandLine.access$1500(CommandLine.java:148)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2415)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2273)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2417)
        at picocli.CommandLine.execute(CommandLine.java:2170)
        at dev.webfx.cli.WebFxCLI.executeCommand(WebFxCLI.java:54)
        at dev.webfx.cli.WebFxCLI.main(WebFxCLI.java:42)`