### PR TITLE
ZHW makes files can be opened in GNU/Linux distributions.

### DIFF
--- a/src/main/java/dev/webfx/cli/commands/Run.java
+++ b/src/main/java/dev/webfx/cli/commands/Run.java
@@ -105,7 +105,7 @@ public final class Run extends CommonSubcommand implements Runnable {
                 if (OperatingSystem.isWindows())
                     ProcessCall.executePowershellCommand(". " + ProcessCall.toShellLogCommandToken(executableFilePath));
                 else
-                    ProcessCall.executeCommandTokens("open", pathName);
+                    ProcessCall.executeCommandTokens("xdg-open", pathName);
             else if (fileName.endsWith(".apk") || fileName.endsWith(".ipa")) {
                 boolean android = fileName.endsWith(".apk");
                 Path gluonModulePath = executableFilePath.getParent();
@@ -123,7 +123,7 @@ public final class Run extends CommonSubcommand implements Runnable {
             } else { // Everything else should be an executable file that we can call directly
                 int exitCode;
                 if (usesOpen && !OperatingSystem.isWindows())
-                    exitCode = ProcessCall.executeCommandTokens("open", pathName);
+                    exitCode = ProcessCall.executeCommandTokens("xdg-open", pathName);
                 else
                     exitCode = ProcessCall.executeCommandTokens(pathName);
                 if (exitCode != 0 && fileName.endsWith(".AppImage"))


### PR DESCRIPTION
Currently,
$ webfx run --gwt 
$ open /home/***/webfx-example-application-gwt/target/webfx-example-application-gwt-1.0.0-SNAPSHOT/webfx_example_application_gwt/index.html
dev.webfx.cli.core.CliException: java.io.IOException: Cannot run program "open": error=2, 没有那个文件或目录

this patch fix this.